### PR TITLE
typo

### DIFF
--- a/_chapters/typescript1.md
+++ b/_chapters/typescript1.md
@@ -386,7 +386,7 @@ function prefix(s: string, n: number) {
 
 const first = curry(prefix)
 
-first(hello)(3) // ERROR!
+first("hello")(3) // ERROR!
 ```
 
 So type checking helps us to create functions correctly, but also to use them correctly.


### PR DESCRIPTION
I think first(hello)(3) should be first("hello")(3) because we are taking the prefix of a string? Unless the point was to show that there is an error because hello does not match the type we defined in the prefix function