### PR TITLE
fix eta conversion typo

### DIFF
--- a/_chapters/haskell3.md
+++ b/_chapters/haskell3.md
@@ -40,7 +40,7 @@ Such operator sectioning allows us to get the right-most parameter of the functi
 ```haskell
 f x = 1 + x
 f x = (1+) x
-f = (+)             -- Eta conversion
+f = (1+)             -- Eta conversion
 ```
 
 ### Compose


### PR DESCRIPTION
f x = 1 + x
f x = (1+) x
f = (+)    // this should be  f = (1+)