### PR TITLE
Update javascript1.md

### DIFF
--- a/_chapters/javascript1.md
+++ b/_chapters/javascript1.md
@@ -60,7 +60,7 @@ w = 2 // note that without a let or const keyword before it, this assignment an 
 ```
 > 2
 
-(Note: there is another legacy keyword for declaring variables in JavaScript `var` that has different scoping rules.  Don’t use it.)
+(Note: The original JavaScript syntax for declaring a variable used the `var` keyword.  However, the scoping of variables declared in this way was strange for people familiar with C and Java scoping rules, and caused much angst.  It has been fixed since ES6 with the `let` and `const` keywords; we prefer these to `var`.)
 
 ## JavaScript Types
 JavaScript has several "primitive types" (simple types that are not [Objects](#objects)).  These include:
@@ -196,6 +196,8 @@ function myFunction(x, y) {
   console.log("hello world") // prints to the console
   return result; // returns the result to the caller
 }
+
+const z = 1; // z is immutable and definied in the global scope
 ```
 
 You invoke (or 'call', or 'apply') a function like so:
@@ -320,7 +322,7 @@ sumTo(10)
 
 The important change is that the recursive call (on the branch of execution that requires it) is now the very last operation to be executed before the function returns.  The computation (`sum + n`) occurs before the recursive call.  Therefore, no local state needs to be stored on the stack.
 
-Note: although it has been proposed for the EcmaScript standard, as of 2020, not all JavaScript engines support tail call optimisation (only WebKit AFAIK).  
+Note: although it has been proposed for the EcmaScript standard, as of 2022, not all JavaScript engines support tail call optimisation (only WebKit AFAIK).  
 
 ## Functions as parameters to other functions
 
@@ -492,7 +494,6 @@ hi('tim')
 
 > "hello tim"
 
-(Note: The original JavaScript syntax for declaring a variable used the `var` keyword.  However, the scoping of variables declared in this way was strange for people familiar with C and Java scoping rules, and caused much angst.  It has been fixed since ES6 with the `let` and `const` keywords; we prefer these to `var`.)
 
 ## Anonymous Functions
 
@@ -562,7 +563,7 @@ You can also have functions with a list of arguments, just put the list in brack
 const greeting = (greeting, person)=> greeting + ' ' + person
 ```
 
-The body of the above functions are simple expressions.  If you need a more complex, multiline body (e.g. with local variables) you can do this but you need to surround the code block with curly braces `{}`:
+The body of the above functions are simple expressions.  If you need a more complex, multiline body (e.g. with local variables) you can do this but you need to surround the code block with curly braces `{}` and use an explicit `return` statement:
 
 ```javascript
 const greeting = (greeting, person)=> {


### PR DESCRIPTION
63: Moved the note from the Functions are objects section to here replacing the old note. Seemed weird where it was

200: the `z` variable is carried over from an earlier example and not defined in this one which is potentially confusing for someone who only runs this example and gets a different output than is shown. I left it outside the function definition to highlight that a variable is accessible in enclosed scopes. `z` is also initialised after it is referenced but this isn't an issue as long as it is initialised before `myFunction` is called.

325: I checked and its still only Safari (webkit) which supports TCO so I updated the date

566: Added reminder about using explicit return statement