### PR TITLE
minor edits.

### DIFF
--- a/_chapters/haskell2.md
+++ b/_chapters/haskell2.md
@@ -13,13 +13,13 @@ title: "Data Types and Type Classes"
 
 ## Algebraic Data Types
 
-We can declare custom types for data in Haskell using the data keyword.  Consider the following declaration of our familiar cons list:
+We can declare custom types for data in Haskell using the `data` keyword.  Consider the following declaration of our familiar cons list:
 
 ```haskell
 data ConsList = Nil | Cons Int ConsList 
 ```
 
-The `|` operator looks rather like the union type operator in TypeScript, and indeed it serves a similar purpose.  Here, a `ConsList` is defined as being a composite type, composed of either Null or a Cons of an Int value and another `ConsList`.  This is called an “algebraic data type” because `|` is like an “or”, or algebraic “sum” operation for combining elements of the type while separating them with a space is akin to “and” or a “product” operation.  
+The `|` operator looks rather like the union type operator in TypeScript, and indeed it serves a similar purpose.  Here, a `ConsList` is defined as being a composite type, composed of either `Nil` or a `Cons` of an `Int` value and another `ConsList`.  This is called an “algebraic data type” because `|` is like an “or”, or algebraic “sum” operation for combining elements of the type while separating them with a space is akin to “and” or a “product” operation.  
 
 Note that neither `Nil` or `Cons` are built in.  They are simply labels for constructor functions for the different versions of a `ConsList` node.  You could equally well call them `EndOfList` and `MakeList` or anything else that’s meaningful to you. `Nil` is a function with no parameters, `Cons` is a function with two parameters.  `Int` is a built-in primitive type for limited-precision integers.
 
@@ -31,7 +31,7 @@ l = Cons 1 $ Cons 2 $ Cons 3 Nil
 
 ## Pattern Matching
 
-In Haskell, we can define multiple versions of a function to handle the instances of an algebraic data types.  This is done by providing a *pattern* in the variable list of the function definition, in the form of an expression beginning with the constructor of the data instance (e.g. `Cons` or `Nil`) and variable names which will be bound to the different fields of the data instance.  
+In Haskell, we can define multiple versions of a function to handle the instances of an algebraic data types.  This is done by providing a *pattern* in the parameter list of the function definition, in the form of an expression beginning with the constructor of the data instance (e.g. `Cons` or `Nil`) and variable names which will be bound to the different fields of the data instance.  
 
 For example, we can create a function to determine a `ConsList`’s length using *pattern matching*; to not only create different definitions of the function for each of the possible instances of a `ConsList`, but also to destructure the non-empty `Cons`:
 
@@ -43,7 +43,7 @@ consLength (Cons _ rest) = 1 + consLength rest
 
 Since we don’t care about the head value in this function, we match it with `_`, an unnamed variable, which effectively ignores it.  Note that another way to conditionally destructure with pattern matching is using a [case statement](/haskell1#conditional-code-constructs-cheatsheet).
 
-Note that such a definition for lists is made completely redundant by Haskell’s wonderful built-in lists, where [] is the empty list, and : is an infix cons operator.  We can pattern match the empty list or destructure (head:rest), e.g.:
+Note that such a definition for lists is made completely redundant by Haskell’s wonderful built-in lists, where `[]` is the empty list, and `:` is an infix cons operator.  We can pattern match the empty list or destructure `(head:rest)`, e.g.:
 
 ```haskell
 intListLength :: [Int] -> Int -- takes a list of Int as input and returns an Int
@@ -53,7 +53,7 @@ intListLength (_:rest) = 1 + intListLength rest
 
 ## Type Parameters and Polymorphism
 
-Similar to typescript Haskell provides *parametric polymorphism*.  That is, the type definitions for functions and data structures (defined with `data` like the ConsList above) can have type parameters (AKA type variables).  For example, the definition `intListLength` above is defined to only work with lists with `Int` elements.  This seems a silly restriction because in this function we don't actually do anything with the elements themselves.  Below, we introduce the type parameter `a` so that the `length` function will able to work with lists of any type of elements.
+Similar to TypeScript Haskell provides *parametric polymorphism*.  That is, the type definitions for functions and data structures (defined with `data` like the `ConsList` above) can have type parameters (AKA type variables).  For example, the definition `intListLength` above is defined to only work with lists with `Int` elements.  This seems a silly restriction because in this function we don't actually do anything with the elements themselves.  Below, we introduce the type parameter `a` so that the `length` function will able to work with lists of any type of elements.
 
 ```haskell
 length :: [a] -> Int -- a is a type parameter
@@ -71,7 +71,7 @@ The following visual summary shows pair data structures with accessor functions 
 
 ## Type Kinds
 
-GHCi allows you to use the `:kind` (or `:k`) command to interrogate the *Kind* of types - think of it as "meta information" about types and their type parameters.  The kind syntax indicates the *arity* or number of type parameters a type has.  Note that it is like the syntax for function types (with the `->`), you can think of it as information about what is required in terms of type parameters to instantiate the type.  If the constructor takes no type parameters the kind is just `*`, (it returns a type), `*->*` if it takes one type parameter, `*->*->*` for two type parameters and so on.
+GHCi allows you to use the `:kind` (or `:k`) command to interrogate the *Kind* of types -- think of it as "meta information" about types and their type parameters.  The kind syntax indicates the *arity* or number of type parameters a type has.  Note that it is like the syntax for function types (with the `->`), you can think of it as information about what is required in terms of type parameters to instantiate the type.  If the constructor takes no type parameters the kind is just `*`, (it returns a type), `*->*` if it takes one type parameter, `*->*->*` for two type parameters and so on.
 
 ![Polymorphism Summary](/assets/images/chapterImages/haskell2/kinds.png)
 
@@ -131,14 +131,14 @@ It’s starting to look a bit like annoying boilerplate code.  Luckily, Haskell 
 data Student = Student { id::Integer, name::String, mark::Int } 
 ```
 
-This creates a record type in every way the same as the above, but the accessor functions id, name and mark are created automatically.
+This creates a record type in every way the same as the above, but the accessor functions `id`, `name` and `mark` are created automatically.
 
 ## Typeclasses
 
 Haskell uses “type classes” as a way to associate functions with types.  A type class is like a promise that a certain type will have specific operations and functions available.  You can think of it as being similar to a [TypeScript interface](/typescript1#interfaces).
 
 Despite the name however, it is not like an ES6/TypeScript class, since a Haskell type class does not actually give definitions for the functions themselves, only their type signatures.  
-The function bodies are defined in “instances” of the type class.  A good starting point for gaining familiarity with type classes is seeing how they are used in the standard Haskell prelude.  From GHCi we can ask for information about a specific typeclass with the `:i` command, for example, Num is a typeclass common to numeric types:
+The function bodies are defined in “instances” of the type class.  A good starting point for gaining familiarity with type classes is seeing how they are used in the standard Haskell prelude.  From GHCi we can ask for information about a specific typeclass with the `:i` command, for example, `Num` is a typeclass common to numeric types:
 
 ```haskell
 GHCi> :i Num
@@ -174,7 +174,7 @@ instance Eq Int
 ... 
 ```
 
-Note again that instances need implement only `==` or `/=` (not equal to), since each can be easily defined in terms of the other.  Still we are missing some obviously important operations, e.g., what about greater-than and less-than?  These are defined in the Ord type class:
+Note again that instances need implement only `==` or `/=` (not equal to), since each can be easily defined in terms of the other.  Still we are missing some obviously important operations, e.g., what about greater-than and less-than?  These are defined in the `Ord` type class:
 ```haskell
 > :i Ord
 class Eq a => Ord a where
@@ -189,7 +189,7 @@ class Eq a => Ord a where
 ```
 
 ```haskell
-The compare function returns an Ordering:
+-- The compare function returns an Ordering:
 > :i Ordering
 data Ordering = LT | EQ | GT 
 ```
@@ -226,10 +226,9 @@ instance Show Suit where
  show Diamond = "O"   -- actual playing card symbols ♠ ♣ ♦ ♥
  show Heart = "V"     -- but GHCi support for unicode 
                       -- characters is a bit sketch
-[Spade .. Heart]
+> [Spade .. Heart]
+[^,&,O,V]
 ```
-
-> [^,&,O,V]
 
 ## Maybe
 
@@ -244,7 +243,7 @@ All the functions we have considered so far are assumed to be *total*.  That is,
 
 ![Total and Partial Functions](/assets/images/chapterImages/haskell2/partialFunctions.png)
 
-For example, the built-in lookup function can be used to search a list of key-value pairs, and fail gracefully by returning `Nothing` if there is no matching key.
+For example, the built-in function `lookup` can be used to search a list of key-value pairs, and fail gracefully by returning `Nothing` if there is no matching key.
 
 ```haskell
 phonebook :: [(String, String)]

--- a/_chapters/haskell3.md
+++ b/_chapters/haskell3.md
@@ -385,7 +385,7 @@ Or a list of functions `[(+1),(+2)]` to things inside a similar context (e.g. a 
 [2,3,4,3,4,5] 
 ```
 
-Note that lists definition of `<*>` produces the cartesian product of the two lists, that is, all the possible ways to apply the functions in the left list to the values in the right list.  It is interesting to look at [the source](https://hackage.haskell.org/package/base-4.14.0.0/docs/src/GHC.Base.html#Applicative) for the definition of `Applicative` for lists on Hackage:
+Note that lists definition of `<*>` produces the Cartesian product of the two lists, that is, all the possible ways to apply the functions in the left list to the values in the right list.  It is interesting to look at [the source](https://hackage.haskell.org/package/base-4.14.0.0/docs/src/GHC.Base.html#Applicative) for the definition of `Applicative` for lists on Hackage:
 
 ```haskell
 instance Applicative [] where
@@ -406,9 +406,9 @@ Just 5
 So:
 - `pure` puts the binary function into the applicative (i.e. `pure (+) :: Maybe (Num -> Num -> Num)`), 
 - then `<*>`ing this function inside over the first `Maybe` value `Just 3` achieves a partial application of the function inside the `Maybe`. This gives a unary function inside a `Maybe`: i.e. `Just (3+) :: Maybe (Num->Num)`. 
-- Finally, we `<*>` this function inside a `maybe` over the remaining `Maybe` value.
+- Finally, we `<*>` this function inside a `Maybe` over the remaining `Maybe` value.
 
-This is where the name "applicative" comes from, i.e. `Applicative` is a type over which a non-unary function may be applied.  Note, that the following use of `fmap` is equivalent and a little bit more concise:
+This is where the name "applicative" comes from, i.e. `Applicative` is a type over which a non-unary function may be applied.  Note, that the following use of `<$>` (infix `fmap`) is equivalent and a little bit more concise:
 
 ```haskell
 > (+) <$> Just 3 <*> Just 2
@@ -453,6 +453,8 @@ lookupStudent :: Integer -> Maybe Student
 lookupStudent sid = Student sid <$> lookup sid names <*> lookup sid marks
 ```
 
+<!-- The following example doesn't typecheck. Commented it out for now.
+
 What if `sid` is also the result of some computation that may fail, and is therefore itself wrapped in a `Maybe` context?  Then we will need to apply the ternary `Student` constructor over three `Maybe`s:
 
 ```haskell
@@ -461,6 +463,7 @@ lookupStudent sid = Student <$> sid <*> lookup sid names <*> lookup sid marks
 ```
 
 So we can see `<*>` may be chained as many times as necessary to cover all the arguments.
+-->
 
 Lists are also instances of `Applicative`.  Given the following types:
 
@@ -502,7 +505,7 @@ GHCi> Card <$> [Spade ..] <*> [Two ..]
 [^2,^3,^4,^5,^6,^7,^8,^9,^10,^J,^Q,^K,^A,&2,&3,&4,&5,&6,&7,&8,&9,&10,&J,&Q,&K,&A,O2,O3,O4,O5,O6,O7,O8,O9,O10,OJ,OQ,OK,OA,V2,V3,V4,V5,V6,V7,V8,V9,V10,VJ,VQ,VK,VA]
 ```
 
-* Try and make the definition of `show` for Rank a one-liner using `zip` and `lookup`.
+* Try and make the definition of `show` for `Rank` a one-liner using `zip` and `lookup`.
 
 <div class="cheatsheet" markdown="1">
 
@@ -524,7 +527,7 @@ instance Applicative ((->)r) where
   (<*>) :: (r -> (a -> b)) -> (r -> a) -> (r -> b)
 ```
 
-This is very convenient for creating pointfree implementations of functions which operate on their parameters more than once.  For example, imagine our `Student` type from above has additional fields with breakdowns of marks: e.g. `exam` and `nonExam`, requiring a function to compute the total mark:
+This is very convenient for creating point-free implementations of functions which operate on their parameters more than once.  For example, imagine our `Student` type from above has additional fields with breakdowns of marks: e.g. `exam` and `nonExam`, requiring a function to compute the total mark:
 
 ```haskell
 totalMark :: Student -> Int
@@ -557,7 +560,7 @@ totalMark = (+) . exam <*> nonExam
 
 As we will [discuss in more detail later](/parsercombinators), a parser is a program which takes some structured input and does something with it.  When we say "structured input" we typically mean something like a string that follows strict rules about its syntax, like source code in a particular programming language, or a file format like JSON.  A parser for a given syntax is a program which you run over some input and if the input is valid, it will do something sensible with it (like give us back some data), or fail: preferrably in a way that we can handle gracefully.  
 
-In Haskell, sophisticated parsers are often constructed from simple functions which try to read a certain element of the expected input and either succeed in consuming that input, returning a tuple containing the rest of the input string and the resultant data, or they fail producing nothing.  We've already seen one type which can be used to encode success or failure, namely `Maybe`.  Here's the most trivial parser function I can think of, it tries to take a character from the input stream and either succeeds or fails if it's given an empty string:
+In Haskell, sophisticated parsers are often constructed from simple functions which try to read a certain element of the expected input and either succeed in consuming that input, returning a tuple containing the rest of the input string and the resultant data, or they fail producing nothing.  We've already seen one type which can be used to encode success or failure, namely `Maybe`.  Here's the most trivial parser function I can think of. It tries to take a character from the input stream and either succeeds consuming it or fails if it's given an empty string:
 
 ```haskell
 -- >>> parseChar "abc"
@@ -594,7 +597,7 @@ parsePlus s =
             Just (s'', '+') -> case parseInt s'' of
                 Just (s''',y) -> Just (s''',x+y)
                 Nothing -> Nothing
-            _ -> Nothing
+            Nothing -> Nothing
         Nothing -> Nothing
 ```
 
@@ -647,7 +650,7 @@ instance Functor Parser where
 
 That solution should not be too hard. We apply the parser and if it passes (equates to a `Just`) we call the function `f` on the `result`.
 
-However, what we are doing is applying a function to the second item of a tuple - that is exactly what the `Functor` instance of a tuple does! So we can rewrite that like this
+However, what we are doing is applying a function to the second item of a tuple -- that is exactly what the `Functor` instance of a tuple does! So we can rewrite that like this
 
 ```haskell
 instance Functor Parser where
@@ -662,7 +665,7 @@ instance Functor Parser where
   fmap f (Parser a) = Parser (\x -> (f <$>) <$> a x )
 ```
 
-Let's try to remove the lambda function by applying the [Point Free](/haskell3/#point-free-code) techniques to remove this lambda function. 
+Let's try to remove the lambda function by applying the [point-free](/haskell3/#point-free-code) techniques to remove this lambda function. 
 
 First, let's add some brackets, to make the evaluation order more explicit.
 ```haskell
@@ -731,7 +734,7 @@ Just ("b",('a',12345))
 
 As both `<$>` and `<*>` have the same precedence, firstly `(,) <$> char` will be evaluated, the result will be then applied to `int`.
 
-So how does `(,) char` work? Well, we parse a character, and then apply that character to the first item of the tuple, therefore:
+So how does `(,) <$> char` work? Well, we parse a character and then make that character the first item of a tuple, therefore:
 ```haskell
 > tupleCharParser = (,) <$> char
 > :t tupleCharParser
@@ -740,7 +743,7 @@ tupleCharParser :: Parser (b -> (Char, b))
 So for the applicative instance the LHS will be the `tupleCharParser` and the RHS will be `int`.
 
 The first step in applicative parsing is to parse the input `i` using the LHS parser, in this case `tupleCharParser`
-This will match the `Just (r1 p1)` case where it will be equal to `Just ("12345"b, ('a',))`. Therefore, `r1` is equal to the unparsed portion of the input `12345` and the result is a tuple partially applied `('a', )`.
+This will match the `Just (r1, p1)` case where it will be equal to `Just ("12345b", ('a',))`. Therefore, `r1` is equal to the unparsed portion of the input `12345b` and the result is a tuple partially applied `('a', )`.
 
 We then run the second parser `int` on the remaining input `"12345b"`. This will match the `Just (r2, p2)` case where it will be equal to `Just ("b", 12345)`, where `r2` is equal to the remaining input `"b"` and `p2` is equal to `"12345"`
 

--- a/_chapters/haskell3.md
+++ b/_chapters/haskell3.md
@@ -46,9 +46,9 @@ f = (1+)             -- Eta conversion
 Has its own operator in haskell `(.)`, inspired by the mathematical function composition symbol `∘`:
 ```haskell
  (f ∘ g) (x) ≡ f (g(x)) -- math notation
- (f . g) x ≡ f (g x)    -- haskell
+ (f . g) x ≡ f (g x)    -- Haskell
 ```
-Again, this gives us another way to get the right-most parameter on it's own outside the body expression:
+Again, this gives us another way to get the right-most parameter on its own outside the body expression:
 ```haskell
 f x = sqrt (1 / x)
 f x = sqrt ((1/) x)     -- operator section
@@ -58,9 +58,9 @@ f = sqrt . (1/)         -- eta conversion
 
 </div>
 
-## Point Free Code
+## Point-Free Code
 
-We have discussed point-free and tacit coding style earlier in these notes. In particular, eta-conversion works in Haskell the same as in lambda calculus and for curried JavaScript functions.  It is easy to do and usually declutters code of unnecessary arguments that help to distill their essence, e.g.:
+We have discussed point-free and tacit coding style earlier in these notes. In particular, eta-conversion works in Haskell the same as in lambda calculus and for curried JavaScript functions.  It is easy to do and usually declutters code of unnecessary arguments, e.g.:
 
 ```haskell
 lessThan :: (Ord a) => a -> [a] -> [a]
@@ -115,7 +115,7 @@ flip f a b = f b a
 
 can also be useful in reversing the arguments of a function or operator in order to get them into a position such that they can be eta-reduced.
   
-In code written by experienced haskellers it is very common to see functions reduced to point-free form.  Does it make it for more readable code?  To experienced haskellers, many times yes.  To novices, perhaps not.  When to do it is a matter of preference.  Experienced haskellers tend to prefer it, they will argue that it reduces functions like the example one above “to their essence”, removing the “unnecessary plumbing” of explicitly named variables.   Whether you like it or not, it is worth being familiar with the tricks above, because you will undoubtedly see them used in practice.  The other place where point free style is very useful is when you would otherwise need to use a lambda function.
+In code written by experienced haskellers it is very common to see functions reduced to point-free form.  Does it make code more readable?  To experienced haskellers, many times yes.  To novices, perhaps not.  When to do it is a matter of preference.  Experienced haskellers tend to prefer it, they will argue that it reduces functions like the example one above “to their essence”, removing the “unnecessary plumbing” of explicitly named variables.   Whether you like it or not, it is worth being familiar with the tricks above, because you will undoubtedly see them used in practice.  The other place where point-free style is very useful is when you would otherwise need to use a lambda function.
 
 Some more (and deeper) discussion is available on the Haskell Wiki.
 
@@ -127,7 +127,7 @@ Some more (and deeper) discussion is available on the Haskell Wiki.
 f a b c = (a+b)*c
 ```
 
-(This is clearly an extreme example but is a useful - and easily verified - practice of operator sectioning, composition and eta-conversion.)
+(This is clearly an extreme example but is a useful -- and easily verified -- practice of operator sectioning, composition and eta-conversion.)
 
 ## Functor
 
@@ -138,7 +138,7 @@ console> [1,2,3].map(x=>x+1)
 [2,3,4]
 ```
 
-Now in haskell:
+Now in Haskell:
 
 ```haskell
 GHCi> map (\i->i+1) [1,2,3]
@@ -166,8 +166,10 @@ In Haskell this pattern is captured in a type class called `Functor`, which defi
 
 ```haskell
 Prelude> :i Functor
-class Functor (f :: * -> *) where
+type Functor :: (* -> *) -> Constraint
+class Functor f where
   fmap :: (a -> b) -> f a -> f b
+...
 instance Functor [] -- naturally lists are an instance
 instance Functor Maybe -- but this may surprise!
 ... -- and some other instances we'll talk about shortly
@@ -198,13 +200,13 @@ instance  Functor Maybe  where
     fmap f (Just a)      = Just (f a)
 ```
 
-So we can `fmap` a function over a Maybe without having to unpackage it:
+So we can `fmap` a function over a Maybe without having to unpack it:
 ```haskell
 GHCi> fmap (+1) (Just 6)
 Just 7 
 ```
 
-This is such a common operation that there is an operator alias for fmap: <$>
+This is such a common operation that there is an operator alias for fmap: `<$>`
 ```haskell
 GHCi> (+1) <$> (Just 6)
 Just 7 
@@ -216,7 +218,7 @@ GHCi> (+1) <$> [1,2,3]
 [2,3,4] 
 ```
 
-Lists of Maybes frequently arise.  For example, the “mod” operation on integers (e.g. mod 3 2 == 1) will throw an error if you pass 0 as the divisor:
+Lists of `Maybe`s frequently arise.  For example, the `mod` operation on integers (e.g. `mod 3 2 == 1`) will throw an error if you pass 0 as the divisor:
 ```haskell
 > mod 3 0
 *** Exception: divide by zero 
@@ -229,13 +231,13 @@ safeMod _ 0 = Nothing
 safeMod numerator divisor = Just $ mod numerator divisor 
 ```
 
-This makes it safe to apply safeMod to an arbitrary list of Integral values:
+This makes it safe to apply `safeMod` to an arbitrary list of `Integral` values:
 ```haskell
 > map (safeMod 3) [1,2,0,4]
 [Just 0,Just 1,Nothing,Just 3] 
 ```
 
-But how do we keep working with such a list of Maybes?  We can map an fmap over the list:
+But how do we keep working with such a list of `Maybe`s?  We can map an `fmap` over the list:
 
 ```haskell
 GHCi> map ((+1) <$>) [Just 0,Just 1,Nothing,Just 3]
@@ -248,7 +250,7 @@ GHCi> ((+1) <$>) <$> [Just 0,Just 1,Nothing,Just 3]
 [Just 1,Just 2,Nothing,Just 4] 
 ```
 
-In addition to lists and Maybes, a number of other built-in types have instances of Functor:
+In addition to lists and `Maybe`s, a number of other built-in types have instances of `Functor`:
 
 ```haskell
 GHCi> :i Functor
@@ -265,7 +267,7 @@ instance Functor ((->) r) where
     fmap = (.) 
 ```
 
-So the composition of functions `f` and `g`: `f . g`, is equivalent to ‘mapping’ `f` over `g`, e.g.  `f <$> g`.  
+So the composition of functions `f` and `g`, `f . g`, is equivalent to ‘mapping’ `f` over `g`, e.g.  `f <$> g`.  
 
 ```haskell
 GHCi> f = (+1)
@@ -299,7 +301,7 @@ data Tree a = Empty
   deriving (Show)
 ```
 
-Note that `Leaf` is a bit redundant as we could also encode nodes with no children as `Node Empty value Empty` - but that's kind of ugly and makes showing our trees more verbose.  Also, having both `Leaf` and `Empty` provides a nice parallel to `Maybe`.
+Note that `Leaf` is a bit redundant as we could also encode nodes with no children as `Node Empty value Empty` -- but that's kind of ugly and makes showing our trees more verbose.  Also, having both `Leaf` and `Empty` provides a nice parallel to `Maybe`.
 
 Here's an example tree defined:
 
@@ -350,9 +352,9 @@ Node (Node (Leaf 3) 5 (Leaf 7)) 9 (Node (Leaf 11) 13 (Leaf 15))
 
 ## Applicative
 
-The applicative introduces a new operator `<*>` (pronounced “apply”), which lets us apply functions inside a computational context.
+The typeclass `Applicative` introduces a new operator `<*>` (pronounced “apply”), which lets us apply functions inside a computational context.
 
-Applicative is a “subclass” of Functor, meaning that an instance of `Applicative` can be ‘`fmap`ed over, but Applicatives also declare (at least) two additional functions, `pure` and `(<*>)` (pronounced ‘apply’ - but I like calling it [“TIE Fighter”](https://en.wikipedia.org/wiki/TIE_fighter)):
+Applicative is a “subclass” of `Functor`, meaning that an instance of `Applicative` can be `fmap`ed over, but Applicatives also declare (at least) two additional functions, `pure` and `(<*>)` (pronounced ‘apply’ -- but I like calling it [“TIE Fighter”](https://en.wikipedia.org/wiki/TIE_fighter)):
 
 ```haskell
 GHCi> :i Applicative
@@ -362,7 +364,7 @@ class Functor f => Applicative (f :: * -> *) where
 ...
 ```
 
-As for `Functor` all instances of the Applicative type-class must satisfy certain laws, which again, are not checked by the compiler.
+As for `Functor` all instances of the Applicative type-class must satisfy certain laws, which again are not checked by the compiler.
 Applicative instances must comply with these laws to produce the expected behaviour.
 You can [read about the Applicative Laws](https://en.wikibooks.org/wiki/Haskell/Applicative_functors)
 if you are interested, but they are a little more subtle than the basic Functor laws above, and it is
@@ -377,13 +379,13 @@ GHCi> Just (+3) <*> Just 2
 Just 5 
 ```
 
-Or a list of functions `[(+1),(+2)]` ), to things inside a similar context (e.g. a list `[1,2,3]`).
+Or a list of functions `[(+1),(+2)]` to things inside a similar context (e.g. a list `[1,2,3]`).
 ```haskell
 > [(+1),(+2)] <*> [1,2,3]
 [2,3,4,3,4,5] 
 ```
 
-Note that lists definition of `<*>` produces the cartesian product of the two lists, that is, all the possible ways to apply the functions in the left list, to the values in the right list.  It is interesting to look at [the source](https://hackage.haskell.org/package/base-4.14.0.0/docs/src/GHC.Base.html#Applicative) for the definition of `Applicative` for lists on Hackage:
+Note that lists definition of `<*>` produces the cartesian product of the two lists, that is, all the possible ways to apply the functions in the left list to the values in the right list.  It is interesting to look at [the source](https://hackage.haskell.org/package/base-4.14.0.0/docs/src/GHC.Base.html#Applicative) for the definition of `Applicative` for lists on Hackage:
 
 ```haskell
 instance Applicative [] where


### PR DESCRIPTION
Minor edits.
I'm not sure whether I agree with the sentence ”This granularity allows the type system to guard against improper use of numbers that might result in loss in precision or division by zero.“ in haskell2.md. Don't see how these typeclasses guard against division by zero.