### PR TITLE
higher order functions: don’t use reserved keyword

### DIFF
--- a/_chapters/higherorderfunctions.md
+++ b/_chapters/higherorderfunctions.md
@@ -334,7 +334,8 @@ const students = ['tim','sally','sam','cindy'],
 We have a function that lets us lookup the id for a student in a particular class:
 
 ```javascript
-const lookup = class=> name=> class[name]
+// 'class' is a reserved keyword in JavaScript
+const lookup = class_=> name=> class_[name]
 ```
 
 Now we can try to find an id for each student, first from ```class1``` but fall back to ```class2``` if it isn’t there:


### PR DESCRIPTION
`class` is a reserved keyword so it can’t be used as a parameter name.