### PR TITLE
Fix glossary (again)

### DIFF
--- a/_chapters/higherorderfunctions.md
+++ b/_chapters/higherorderfunctions.md
@@ -1,6 +1,6 @@
 ---
 layout: chapter
-title: "Higher Order Functions"
+title: "Higher-Order Functions"
 ---
 
 

--- a/_data/chapters.yml
+++ b/_data/chapters.yml
@@ -58,7 +58,7 @@
   url: /asteroids/
   description: |
     A fully worked example of FRP using RxJS Observables to create an in-browser version of a classic arcade game.
-- title: Higher Order Functions
+- title: Higher-Order Functions
   url: /higherorderfunctions/
   description: |
     - Understand that [Higher-Order Functions](/higherorderfunctions/#higher-order-functions) are those which take other functions as input parameters or which return functions

--- a/_data/glossary.yml
+++ b/_data/glossary.yml
@@ -41,10 +41,10 @@
   definition: Procedural languages are basically *imperative* in nature, but add the concept of named *procedures*, i.e. named subroutines that may be invoked from elsewhere in the program, with parameterised variables that may be passed in.
   first_appeared: levelsofabstraction
 - term: Object-oriented
-  definition: Object-oriented languages are built around the concept of *objects* where an objects captures the set of data (state) and behaviours (methods) associated with entities in the system.  
+  definition: Object-oriented languages are built around the concept of *objects* where an objects captures the set of data (state) and behaviours (methods) associated with entities in the system.
   first_appeared: levelsofabstraction
 - term: Declarative
-  definition: Declarative languages focus on declaring *what* a procedure (or function) should do rather than *how* it should do it.  
+  definition: Declarative languages focus on declaring *what* a procedure (or function) should do rather than *how* it should do it.
   first_appeared: levelsofabstraction
 - term: Functional
   definition: Functional languages are built around the concept of composable functions.  Such languages support *higher order functions* which can take other functions as arguments or return new functions as their result, following the rules of the *Lambda Calculus*.

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -139,6 +139,11 @@ input:checked + .slider:before {
   display: none;
 }
 
+.site-nav {
+  // Prevent .glossary-term from floating on top of it
+  z-index: 1;
+}
+
 .site-nav .trigger {
   display: flex;
   align-items: center;


### PR DESCRIPTION
This PR fixes this glossary issue:
![The curried combinator'> K-Combinator looks like:](https://github.com/user-attachments/assets/3dfa8cb0-6d72-410b-8825-b1adedf2de05)
![parser combinators'>Parser Combinators >](https://github.com/user-attachments/assets/ff7be7eb-11e8-4ab6-a2e2-059fc3b512ff)

This happened whenever a glossary term was a substring of another one (e.g. ‘K-Combinator’ and ‘Combinator’). ‘K-Combinator’ would generate HTML including `<span data-term="k-combinator">`, and then the `combinator` in `data-term="k-combinator"` would get replaced with another glossary term `<span>`.

I also fixed this issue:
![](https://github.com/user-attachments/assets/6a19faca-c4dd-4836-9134-2d5f48e9f513)

(thanks @harry-breslin for pointing out this issue)