### PR TITLE
Fix bullet velocity

### DIFF
--- a/_chapters/asteroids.md
+++ b/_chapters/asteroids.md
@@ -523,7 +523,7 @@ Now we define functions to create objects:
     return {
       id: `bullet${s.objCount}`,
       pos:s.ship.pos.add(d.scale(s.ship.radius)),
-      vel:s.ship.vel.add(d.scale(-2)),
+      vel:s.ship.vel.add(d.scale(2)),
       createTime:s.time,
       thrust:false,
       angle:0,


### PR DESCRIPTION
I may be mistaken, but wouldn't scaling the added velocity of the bullet by -2 result in it firing "backwards" (relative to the velocity of the ship)? For example, assuming linear motion:
- If ship.vel < unitVecInDirection * 2, bullet fires in opposite direction that ship is pointing in
- If ship.vel == unitVecInDirection * 2, bullet has zero velocity (i.e., is stationary)
- If ship.vel > unitVecInDirection * 2, bullet fires in same direction but with slower speed, appears to travel backwards w.r.t. ship

This velocity value also appears to be inconsistent with the StackBlitz implementation:
https://stackblitz.com/edit/asteroids2023?file=src%2Fstate.ts%3AL107:
```ts
class Shoot implements Action {
    apply = (s: State) => ({ ...s,
        bullets: s.bullets.concat([
            ((unitVec: Vec) =>
                createBullet
                    ({ id: String(s.objCount), createTime: s.time })
                    ({ radius: Constants.BulletRadius, 
                       pos: s.ship.pos.add(unitVec.scale(s.ship.radius)) })
                    (s.ship.vel.add(unitVec.scale(Constants.BulletVelocity)))
            )(Vec.unitVecInDirection(s.ship.angle))]),
        objCount: s.objCount + 1
    })
}
```
https://stackblitz.com/edit/asteroids2023?file=src%2Ftypes.ts: `BulletVelocity: 2`