### PR TITLE
remove ‘AKA concatMap’ in mergeMap comment

### DIFF
--- a/_chapters/functionalreactiveprogramming.md
+++ b/_chapters/functionalreactiveprogramming.md
@@ -225,12 +225,12 @@ The following functions create Observable streams from various sources.
 
 ```typescript
 // produces the list of arguments as elements of the stream
-of<T>(...args: T[]): Observable<T> 
+of<T>(...args: T[]): Observable<T>
 
 // produces a stream of numbers from “start” until “count” been emitted
 range(start?: number, count?: number): Observable<number>
 
-// produces a stream for the specified event, element type depends on 
+// produces a stream for the specified event, element type depends on
 // event type and should be specified by the type parameter, e.g.: MouseEvent, KeyboardEvent
 fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>
 
@@ -239,7 +239,7 @@ fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>
 interval(period?: number): Observable<number>
 
 // after given initial delay, emit numbers in sequence every specified duration
-timer(initialDelay: number, period? : number): Observable<number>
+timer(initialDelay: number, period?: number): Observable<number>
 
 ```
 
@@ -248,14 +248,14 @@ timer(initialDelay: number, period? : number): Observable<number>
 Creating new Observable streams from existing streams
 
 ```typescript
-// create a new Observable stream from the merge of multiple Observable streams.  
+// create a new Observable stream from the merge of multiple Observable streams.
 // The resulting stream will have elements of Union type.
 // i.e. the type of the elements will be the Union of the types of each of the merged streams
 // Note: there is also an operator version.
-merge<T, U...>(t: Observable<T>, u: Observable<U>, ...): Observable<T|U...>
+merge<T, U...>(t: Observable<T>, u: Observable<U>, ...): Observable<T | U | ...>
 
-// create n-ary tuples (arrays) of the elements at the head of each of the incoming streams 
-zip<T,U...>(t: Observable<T>, r: Observable<U>):Observable<[T,U,...]>
+// create n-ary tuples (arrays) of the elements at the head of each of the incoming streams
+zip<T, U...>(t: Observable<T>, r: Observable<U>):Observable<[T, U, ...]>
 ```
 
 ### Observable methods
@@ -291,15 +291,15 @@ take<T>(n: number)
 // take the last element
 last<T>()
 
-// AKA concatMap/flatMap: produces an Observable<R> for every input stream element<T>
+// AKA flatMap: produces an Observable<R> for every input stream element T
 mergeMap<T, R>(project: (value: T) => Observable<R>)
 
 // accumulates values from the stream
 scan<T, R>(accumulator: (acc: R, value: T) => R, seed?: R)
 
 // push an arbitrary object on to the start/end of the stream
-startWith<T>(o:T)
-endWith<T>(o:T)
+startWith<T>(o: T)
+endWith<T>(o: T)
 ```
 
 </div>


### PR DESCRIPTION
This is to avoid confusion with `concatMap` for observables, which is different from `mergeMap`.