### PR TITLE
fix dark mode colours

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,21 +18,21 @@
             </span>
             </label>
 
-            <div class="trigger">
-            {%- for path in page_paths -%}
-                {%- assign my_page = site.pages | where: "path", path | first -%}
-                {%- if my_page.title -%}
-                <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-                {%- endif -%}
-            {%- endfor -%}
-            <!-- Radio Switch -->
-            <div id="toggle-div" style="display: none;">
-                <p class="page-link" style="margin-bottom: 0px;">Show Solutions?</p>
-                <label class="switch" style="vertical-align: middle;">
-                    <input type="checkbox" id="toggle-switch">
-                    <span class="slider round"></span>
-                </label>
-            </div>
+            <div id="nav-menu" class="trigger">
+                {%- for path in page_paths -%}
+                    {%- assign my_page = site.pages | where: "path", path | first -%}
+                    {%- if my_page.title -%}
+                    <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+                    {%- endif -%}
+                {%- endfor -%}
+                <!-- Radio Switch -->
+                <div id="toggle-div" style="display: none;">
+                    <p class="page-link" style="margin-bottom: 0px;">Show Solutions?</p>
+                    <label class="switch" style="vertical-align: middle;">
+                        <input type="checkbox" id="toggle-switch">
+                        <span class="slider round"></span>
+                    </label>
+                </div>
             </div>
         </nav>
         {%- endif -%}

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,13 +1,13 @@
-.cheatsheet {
-  background-color: #e8e8e8;
-  padding: 8px 12px;
-}
-
-.glossary {
+.cheatsheet, .glossary {
   background-color: #f3f0f0;
   padding: 8px 12px;
 }
 
+@media (prefers-color-scheme: dark) {
+  .cheatsheet, .glossary {
+    background-color: #333;
+  }
+}
 
 .post-header {
   &, h1 {
@@ -37,7 +37,7 @@
   margin-left: -120px;
 
   padding: 10px;
-  background: #fff;
+  background: var(--minima-background-color);
   border: 1px solid #ccc;
   box-shadow: 0 0 10px rgba(0,0,0,0.1);
   z-index: 1000;
@@ -47,6 +47,12 @@
 
   /* Force it to be the default font */
   font: 400 16px / 1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+@media (prefers-color-scheme: dark) {
+  .glossary-popup {
+    border-color: #444;
+  }
 }
 
 
@@ -184,4 +190,24 @@ input:checked + .slider:before {
 .spoiler[data-revealed] code {
   background-color: #aaa;
   border: 1px solid #999;
+}
+
+@media (prefers-color-scheme: dark) {
+  .spoiler, .spoiler * {
+    color: #333;
+  }
+
+  .spoiler {
+    color: white;
+    background-color: #333;
+  }
+
+  .spoiler[data-revealed], .spoiler[data-revealed] * {
+    background-color: #333;
+  }
+
+  .spoiler[data-revealed] code {
+    background-color: #222;
+    border-color: #111;
+  }
 }

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -144,6 +144,11 @@ input:checked + .slider:before {
   z-index: 1;
 }
 
+
+#nav-menu {
+  display: flex;
+}
+
 .site-nav .trigger {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fix a couple of the issues from the Minima v3 update (#121):

1. Fix the solutions button from

<img width="352" alt="image" src="https://github.com/user-attachments/assets/6c5c8cd0-09cc-421f-a395-40a6dc971450">

to

<img width="563" alt="image" src="https://github.com/user-attachments/assets/cadf4616-f6d1-47b5-8581-108f2b6bf4ba">

2. Fix dark mode colours (e.g. cheatsheets and glossary) from

![image](https://github.com/user-attachments/assets/2e56c3ba-8435-44d7-890f-f7dd912cfb68)

to

<img width="810" alt="image" src="https://github.com/user-attachments/assets/0ed5361c-8489-487c-ab7b-85ac04b4656d">
