### PR TITLE
haskell vscode extension manage hls via path

### DIFF
--- a/_chapters/haskell0.md
+++ b/_chapters/haskell0.md
@@ -171,6 +171,12 @@ This may download any missing dependencies.
 
 Install the [Haskell extension](https://marketplace.visualstudio.com/items?itemName=haskell.haskell). This provides Haskell language support including language server, syntax highlighting, and linting.
 
+If you are asked
+
+> How do you want the extension to manage/discover HLS and the relevant toolchain?
+
+select the ‘Manually via PATH’ option. This corresponds to the ‘Haskell: Manage HLS’ option in VS Code, which should be set to `PATH` (`"haskell.manageHLS": "PATH"`).
+
 ### Optional Extras
 
 These may take a while to install, so if you’re installing Haskell during your applied class, it is worth getting started on your applied session work instead.


### PR DESCRIPTION
I forgot to push this commit sorry

Add some instructions for getting the VS Code Haskell extension to find HLS via `PATH`, rather than having it attempt to manage it itself via GHCup (which seems to have some issues occasionally with installing the wrong version?)