### PR TITLE
Fix grammatical and syntax errors in course materials

### DIFF
--- a/_chapters/javascript1.md
+++ b/_chapters/javascript1.md
@@ -1119,7 +1119,7 @@ class Person:
         self.occupation = occupation
 
     @property
-    def greeting():
+    def greeting(self):
        return f"Hi, my name's {self.name} and I {self.occupation}!"
 
     def say_hello(self):

--- a/_chapters/monad.md
+++ b/_chapters/monad.md
@@ -399,7 +399,7 @@ they all take a common parameter, e.g. a line break character.
 ```haskell
 greet linebreak = "Dear Gentleperson,"++linebreak 
 body sofar linebreak = sofar ++ linebreak ++ "It has come to my attention that… " ++ linebreak
-signoff sofar linebreak = sofar ++ linebreak ++ "Your’s truly," ++ linebreak ++ "Tim" ++ linebreak
+signoff sofar linebreak = sofar ++ linebreak ++ "Yours truly," ++ linebreak ++ "Tim" ++ linebreak
 putStrLn $ (greet >>= body >>= signoff) "\r\n"
 ```
 


### PR DESCRIPTION
- Fixed missing self parameter in Python @property method (javascript1.md:1122)
- Corrected apostrophe usage: "Your's" to "Yours" (monad.md:402)