### PR TITLE
Change modulo to remainder in JS introduction

### DIFF
--- a/_chapters/javascript1.md
+++ b/_chapters/javascript1.md
@@ -201,11 +201,11 @@ Here’s a cheatsheet:
 ### Binary Operators
 
 ```javascript
-x % y   // modulo
-x == y  // loose* equality
-x != y  // loose* inequality
-x === y // strict+ equality
-x !== y // strict+ inequality
+x % y   // remainder¹
+x == y  // loose² equality
+x != y  // loose² inequality
+x === y // strict³ equality
+x !== y // strict³ inequality
 
 a && b   // logical and
 a || b   // logical or
@@ -214,9 +214,11 @@ a & b   // bitwise and
 a | b   // bitwise or
 ```
 
-\* Loose (in)equality means type conversion may occur
+¹ Same as modulo for positive integers, but differs with negative signs, unlike, for example, Python (e.g., `-11 % 4` is `-3` in JS, not `1`). See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description).
 
-\+ Use strict (in)equality if type is expected to be the same
+² Loose (in)equality means type conversion may occur
+
+³ Use strict (in)equality if type is expected to be the same
 
 ### Unary Operators
 

--- a/_chapters/javascript1.md
+++ b/_chapters/javascript1.md
@@ -214,7 +214,7 @@ a & b   // bitwise and
 a | b   // bitwise or
 ```
 
-¹ Same as modulo for positive integers, but differs with negative signs, unlike, for example, Python (e.g., `-11 % 4` is `-3` in JS, not `1`). See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description).
+¹ Not true modulo. It keeps the sign of the first number, so `-11 % 4` is `-3` (unlike Python, Ruby, Perl, etc. which return `1`).
 
 ² Loose (in)equality means type conversion may occur
 


### PR DESCRIPTION
Minor correction to the operators snippet. `%` is a [remainder operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description) and not a true modulo, so I added a quick note and comparison to Python & Perl. I wasn't sure what symbol to use for the footnotes, so I switched them to numbers.