### PR TITLE
Fix haskell typos

### DIFF
--- a/_chapters/eithers.md
+++ b/_chapters/eithers.md
@@ -27,7 +27,7 @@ The `Left`/`Right` convention is also more general than a `Success`/`Error` nami
 
 ## Usage of Either
 
-We can use `Either` to help us with error catching, similar to a `Maybe` type. However, the error case has a value rather than `Nothing`, allowing to store an error message to give information to the programmer/user.
+We can use `Either` to help us with error catching, similar to a `Maybe` type. However, the error case has a value rather than `Nothing`, allowing us to store an error message to give information to the programmer/user.
 
 ```haskell
 divide :: Double -> Double -> Either String Double

--- a/_chapters/haskell1.md
+++ b/_chapters/haskell1.md
@@ -157,7 +157,7 @@ The default Haskell lists are cons lists (linked lists defined with a `cons` fun
 
 ```haskell
 []           -- an empty list
-[1,2,3,4]    -- a simple lists of values
+[1,2,3,4]    -- a simple list of values
 [1..4]       -- ==[1,2,3,4] (..) is range operator
 1:[2,3,4]    -- ==[1,2,3,4], use `:` to “cons” an element to the start of a list
 1:2:3:[4]    -- ==[1,2,3,4], you can chain `:`
@@ -243,11 +243,14 @@ Note that our "Hello world!" function to recursively compute the $n^\text{th}$ F
 ```haskell
 lazyFibs = 1 : 1 : zipWith (+) lazyFibs (tail lazyFibs)
 ```
+
 We can then create as much of the list as we need:
+
 ```haskell
 take 10 lazyFibs
 [1,1,2,3,5,8,13,21,34,55]
 ```
+
 This works (as opposed to the recursive definition of `lazyFibs` causing an infinite loop) because Haskell's lazy evaluation only forces evaluation of as much of the list as absolutely necessary, e.g. to output the result of `take 10`.
 ![Deck Observable Visualised](/assets/images/chapterImages/haskell1/zip.gif)
 
@@ -413,7 +416,7 @@ fibs n = fibs (n-1) + fibs (n-2)
 if <condition> then <case 1> else <case 2>
 ```
 
-just like JavaScript’s ternary if operator: `<condition> ? <case 1> : <case 3>`
+just like JavaScript’s ternary if operator: `<condition> ? <case 1> : <case 2>`
 
 ```haskell
 fibs n = if n == 0 then 1 else if n == 1 then 1 else fibs (n-1) + fibs (n-2)

--- a/_chapters/haskell3.md
+++ b/_chapters/haskell3.md
@@ -815,7 +815,7 @@ This definition takes a single parameter a and returns a function. This function
 
 ```haskell
 pure :: a -> (r -> a)
-pure a _ = -> a
+pure a _ = a
 ```
 
 The function `pure` helps you create a function that, no matter what the second input is, will always return this first value, this is exactly the K-combinator.
@@ -868,7 +868,7 @@ apply f = f <*> id
 This will allow us to make more functions point-free
 
 ```haskell
-square :: Num a => a => a
+square :: Num a => a -> a
 square a = a * a
 ```
 
@@ -1076,7 +1076,8 @@ instance Functor Parser where
         Just (rest, result) -> Just (rest, f result)
         _ -> Nothing
 ```
-These definition is a bit tedious.  We have to explicitly run the parser and unbox the result of the given parser (but only if it succeeds), in order to apply the function f to the result.
+
+This definition is a bit tedious.  We have to explicitly run the parser and unbox the result of the given parser (but only if it succeeds), in order to apply the function f to the result.
 
 If we take advantage of the fact that everything buried away inside the `Parser` is also an instance `Functor`, we can have a much simpler definition of `fmap` for `Parser`:
 
@@ -1218,7 +1219,7 @@ So for the applicative instance, the LHS will be the `charPairParser` and the RH
 That is, the first step in applicative parsing is to parse the input `i` using the LHS parser, which is what we called here `charPairParser`.
 This will match the `Just (r1, p1)` case where it will be equal to `Just ("12345b", ('a',))`. Therefore, `r1` is equal to the unparsed portion of the input `12345b` and the result is a tuple partially applied `('a', )`.
 
-We then run the second parser `int` on the remaining input `"12345b"`. This will match the `Just (r2, p2)` case where it will be equal to `Just ("b", 12345)`, where `r2` is equal to the remaining input `"b"` and `p2` is equal to `"12345"`
+We then run the second parser `int` on the remaining input `"12345b"`. This will match the `Just (r2, p2)` case where it will be equal to `Just ("b", 12345)`, where `r2` is equal to the remaining input `"b"` and `p2` is equal to `12345`
 
 We then return `Just (r2, p1 p2)`, which will evaluate to `Just ("b", ('a',12345))`.
 
@@ -1310,7 +1311,7 @@ So in this scenario, our function `f` is `(\a b -> a)` and our `(Parser p)` is t
 
 Therefore, `(\a b -> a) <$> int` will result in `Just ("+", (\a b -> a) 123)`
 
-Now, we want need to consider the second half, which is
+Now, we need to consider the second half, which is
 
 `Just ("+", (\a b -> a) 123)` being applied to `(is '+')`
 

--- a/_chapters/monad.md
+++ b/_chapters/monad.md
@@ -423,7 +423,7 @@ putStrLn $ (greet >>= body >>= signoff) "\r\n"
 >
 > It has come to my attention that…  
 >
-> Your’s truly,  
+> Yours truly,  
 > Tim
 
 In the next example we use the argument `3` in three different functions without passing it directly to any of them.

--- a/_chapters/statemonad.md
+++ b/_chapters/statemonad.md
@@ -113,17 +113,18 @@ fmap f r = Rand $ (f <$>)<$> next r
 ## Applicative
 
 ```haskell
-pure :: a -> Rand a
-pure x = Rand (,x) -- Return the input seed and the value
+instance Applicative Rand where
+  pure :: a -> Rand a
+  pure x = Rand (,x) -- Return the input seed and the value
 
 
-(<*>) :: Rand (a -> b) -> Rand a -> Rand b
-left <*> right = Rand h
-where
-    h s = (s'', f v) -- Need to return a function of type (Seed -> (Seed, Value))
+  (<*>) :: Rand (a -> b) -> Rand a -> Rand b
+  left <*> right = Rand h
     where
-        (s', f) = next left s   -- Get the next seed and function from the left Rand
-        (s'', v) = next right s' -- Get the next seed and value from the right Rand
+      h s = (s'', f v) -- Need to return a function of type (Seed -> (Seed, Value))
+        where
+          (s', f) = next left s   -- Get the next seed and function from the left Rand
+          (s'', v) = next right s' -- Get the next seed and value from the right Rand
 ```
 
 `<*>` constructs a new Rand value Rand h by:
@@ -256,7 +257,7 @@ rollDie = do
   pure (genRand 1 6 s) -- computes a random number and puts back in the context
 ```
 
-We can also write this using bind notation, where we `modify nextSeed` to update the seed. We then use `>>` to ignore the result (i.e., the `()`). We use get to put the seed as the value, which is then binded on to `s` and used to generate a random number. We then use pure to update the value, the seed updating is handled by our bind!
+We can also write this using bind notation, where we `modify nextSeed` to update the seed. We then use `>>` to ignore the result (i.e., the `()`). We use get to put the seed as the value, which is then bound on to `s` and used to generate a random number. We then use pure to update the value, the seed updating is handled by our bind!
 
 ```haskell
 rollDie :: Rand Int


### PR DESCRIPTION
Fixes various minor typos / syntax in the Haskell half of the lessons